### PR TITLE
Fixed crashed when using VPET on UnrealEditor but with -game flag

### DIFF
--- a/SceneDistribution_Unreal/UE5/UE 5.3/Plugins/VPET/Source/VPET/Private/VPETModule.cpp
+++ b/SceneDistribution_Unreal/UE5/UE 5.3/Plugins/VPET/Source/VPET/Private/VPETModule.cpp
@@ -198,9 +198,11 @@ void AVPETModule::BeginPlay()
 
 #if WITH_EDITOR
 	// Manage editor selection changes 
-	FLevelEditorModule& levelEditor = FModuleManager::GetModuleChecked<FLevelEditorModule>("LevelEditor");
-	FLevelEditorModule::FActorSelectionChangedEvent fasce = levelEditor.OnActorSelectionChanged();
-	levelEditor.OnActorSelectionChanged().AddUObject(this, &AVPETModule::HandleOnActorSelectionChanged);
+	FLevelEditorModule* levelEditor = FModuleManager::GetModulePtr<FLevelEditorModule>("LevelEditor");
+	if (levelEditor != nullptr) {
+		FLevelEditorModule::FActorSelectionChangedEvent fasce = levelEditor->OnActorSelectionChanged();
+		levelEditor->OnActorSelectionChanged().AddUObject(this, &AVPETModule::HandleOnActorSelectionChanged);
+	}
 #endif // WITH_EDITOR
 	// subscribe to delegate 
 	for (auto i=1; i<VPET_SceneObjectList.Num(); i++)


### PR DESCRIPTION
When UnrealEditor is used with the -game flag (eg. "UnrealEditor.exe <path-to-your-project> -game"), the "LevelEditor" module doesn't exist.
With this fix, we just check if the module exists or not before trying to do anything else.