### PR TITLE
Improved reliability of add_path function Blender

### DIFF
--- a/VPET_Blender/Source/tools.py
+++ b/VPET_Blender/Source/tools.py
@@ -219,52 +219,38 @@ def parent_to_root():
 def add_path(character, path_name):
 
     # Check whether an Animation Preview object is already present in the scene
-    if path_name in bpy.context.scene.objects:
+    if path_name in bpy.data.objects:
         # If yes, save it
         print("Animation Preview object found")
-        anim_path = bpy.context.scene.objects[path_name]
-
+        anim_path = bpy.data.objects[path_name]
     else:
         # If not, create it as an empty object 
         print("Creating new Animation Preview object")
         anim_path = bpy.data.objects.new(path_name, None)
         bpy.data.collections["Collection"].objects.link(anim_path)  # Add anim_prev to the scene
 
+    if len(anim_path.children) == 0:
         # Create default control point in the origin 
         point_zero = make_point()
         point_zero.parent = anim_path
 
-    #rna_ui = get_rna_ui()
-    # Check whether AnimPrev has a Control Points attribute
-    if not "Control Points" in anim_path:
-        # If not, create it as a list of one element (i.e. the default control point)
-        anim_path["Control Points"] = [point_zero]
-    # Check whether AnimPrev has a Control Points attribute
-    if not "Auto Update" in anim_path:
-        # If not, create it as a list of one element (i.e. the default control point)
-        anim_path["Auto Update"] = False
-    # Check whether AnimPrev has a Total Frames attribute
-    if not "Total Frames" in anim_path:
-        # If not, create it and give it the default value of 180
-        anim_path["Total Frames"] = 180
-        # rna_ui["Total Frames"] = {
-        #     "description": "Total number of frames for the animation along the drawn path",
-        #     "default": 180,
-        #     "min": 0,
-        # }
-        '''TODO check this out bpy.ops.wm.properties_edit(data_path="object", property_name="Total Frames", property_type='INT', is_overridable_library=False, description="", use_soft_limits=False, default_int=(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), min_int=0, max_int=2147483647, soft_min_int=-2147483648, soft_max_int=2147483647, step_int=1, subtype='NONE', eval_string="180")
-'''
-    bpy.context.space_data.overlay.show_relationship_lines = False  # Disabling Relationship Lines to declutter scene view
+        anim_path["Control Points"] = [point_zero]                      # Add Control Points property and initialise it with the first "default" point. It will hold the list of all the Control Point Objects that make up the Animation Path
+        anim_path["Auto Update"] = False                                # Add Auto Update property. It will hold the "mode status" for the Animation Path. It is used to enable/disable advanced editing features. 
 
-    # Select and set as active the new point
-    point_zero.select_set(True)
-    bpy.context.view_layer.objects.active = point_zero
+        bpy.context.space_data.overlay.show_relationship_lines = False  # Disabling Relationship Lines to declutter scene view
+        anim_path.lock_location[2] = True                               # Locking Z-component of the Animation Path, as it's going to be done with its Control Points
 
+    # Select and set as active the first point of the Path
+    anim_path["Control Points"][0].select_set(True)
+    bpy.context.view_layer.objects.active = anim_path["Control Points"][0]
     
     #? We could allow multiple paths in the scene (for now only one for simplifying testing)
     #? We could associate control paths to character by simply setting them as children of an armature object
     #anim_path.parent = character    # Set the selected character as the parent of the animation preview object
 
+### Function used to create a new Control Point. It creates the mesh geometry if it's not already present in the scene and adds and initialises the various properties
+#   @param  spawn_location  Position in World Space, where the new point will be displayed
+#   @returns   Reference of the created Control Point Object  
 def make_point(spawn_location = (0, 0, 0)):
     # Generate new planar isosceles triangle mesh called ptr_mesh
     vertices = [(-0.0625, 0, -0.0625), (0.0625, 0, 0.0625), (0, -0.25, 0), (0.0625, 0, -0.0625), (-0.0625, 0, 0.0625)]
@@ -310,26 +296,22 @@ def make_point(spawn_location = (0, 0, 0)):
     
     return ptr_obj
 
+### Function that adds a new point to the Animation Path
+#   @param  anim_path   Reference to the Animation Path to which the point has to be added
+#   @param  pos         Position in which to the new point should be inserted (default -1, i.e. at the endof the list) 
+#   @param  after       Whether the point is being added before or after the selected point (only important to compute the correct offset)
 def add_point(anim_path, pos=-1, after=True):
     spawn_proportional_offset = mathutils.Vector((0, -1.5, 0))
-    if after:
-        # Calculate offset proportionally to the dimensions of the mesh of the pointer (Control Point) object and in relation to the rotation of the PREVIOUS control point
-        base_rotation = anim_path["Control Points"][pos].rotation_euler
-        spawn_offset = anim_path["Control Points"][pos].dimensions * spawn_proportional_offset
-        spawn_offset.rotate(base_rotation)
-        # Create new point, place it next to the CURRENTLY SELECTED point, and select it
-        new_point = make_point(anim_path["Control Points"][pos].location + spawn_offset)
-        new_point.rotation_euler = base_rotation    # Rotate the pointer so that it aligns with the previous one
-        new_point.parent = anim_path                # Parent it to the selected (for now the only) path
-    else:
-        # Calculate offset proportionally to the dimensions of the mesh of the pointer (Control Point) object and in relation to the rotation of the PREVIOUS control point
-        base_rotation = anim_path["Control Points"][pos].rotation_euler
-        spawn_offset = anim_path["Control Points"][pos].dimensions * spawn_proportional_offset * -1  # flipping the offset to insert the point behind the selected one
-        spawn_offset.rotate(base_rotation)
-        # Create new point, place it next to the CURRENTLY SELECTED point, and select it
-        new_point = make_point(anim_path["Control Points"][pos].location + spawn_offset)
-        new_point.rotation_euler = base_rotation    # Rotate the pointer so that it aligns with the previous one
-        new_point.parent = anim_path                # Parent it to the selected (for now the only) path
+
+    # Calculate offset proportionally to the dimensions of the mesh of the pointer (Control Point) object and in relation to the rotation of the PREVIOUS control point
+    base_rotation = anim_path["Control Points"][pos].rotation_euler
+    spawn_offset = anim_path["Control Points"][pos].dimensions * spawn_proportional_offset
+    spawn_offset = spawn_offset if after else spawn_offset * -1  # flipping the offset so that the point gets spawned behind the selected one (if after == False)
+    spawn_offset.rotate(base_rotation)
+    # Create new point, place it next to the CURRENTLY SELECTED point, and select it
+    new_point = make_point(anim_path["Control Points"][pos].location + spawn_offset)
+    new_point.rotation_euler = base_rotation    # Rotate the pointer so that it aligns with the previous one
+    new_point.parent = anim_path                # Parent it to the selected (for now the only) path
 
     print("Number of Control Points " + str(len(anim_path["Control Points"])))
     if len(anim_path["Control Points"]) > 0:
@@ -338,11 +320,10 @@ def add_point(anim_path, pos=-1, after=True):
         control_points = anim_path["Control Points"]
         control_points.append(new_point)
         anim_path["Control Points"] = control_points
+        # If the position is not -1 (i.e. end of list), move the point to the correct position
         if pos >= 0:
-            if after:
-                move_point(new_point, pos+1)
-            else:
-                move_point(new_point, pos)
+            # If inserting AFTER the current point, move to the next position (pos+1), otherwise inserting at the position of the current point, which will be moved forward as a result  
+            move_point(new_point, pos+1) if after else move_point(new_point, pos)
     else:
         # If Control Points has no elements, delete the property and create it ex-novo
         del anim_path["Control Points"]
@@ -367,7 +348,7 @@ def add_point(anim_path, pos=-1, after=True):
     new_point.select_set(True)
     bpy.context.view_layer.objects.active = new_point
 
-# Function that builds the name of a Control Point object given the position that it should take up in the Control Path
+### Function that builds the name of a Control Point object given the position that it should take up in the Control Path
 def get_pos_name(pos):
     suffix = ""
     if pos < 0:
@@ -383,7 +364,7 @@ def get_pos_name(pos):
         suffix = ("." + str(pos))
     return "Pointer" + suffix
 
-# Function to move a Control Point in the Control Path, given the point to move and the position it should take up
+### Function to move a Control Point in the Control Path, given the point to move and the position it should take up
 def move_point(point, new_pos):
     print("Moving " + point.name + " to position " + str(new_pos))
     # Get the current position of the active object
@@ -462,13 +443,14 @@ def update_curve(anim_path):
 
     control_path = bpy.data.objects.new('Control Path', bezier_curve_obj)           # Create a new Control Path Object with the geometry data of the Bézier Curve
     control_path.parent = anim_path                                                 # Make the Control Path a child of the Animation preview Object
+    control_path.lock_location[2] = True                                               # Locking Z-component of the Control Path, as it's going to be done with its Control Points
     bpy.data.collections["Collection"].objects.link(control_path)                   # Add the Control Path Object in the scene
 
     for area in bpy.context.screen.areas:
         if area.type == 'PROPERTIES':
             area.tag_redraw()
 
-# Function for drawing number labels next to the control points
+### Function for drawing number labels next to the control points
 def draw_pointer_numbers_callback(self, context):
     # BLF drawing routine
     anchor_3d_pos = mathutils.Vector((0,0,0))


### PR DESCRIPTION
- Control Path is now locked on the Z-axis
- No more errors when trying to add an additional path (just nothing happens for now)
- Is it possible to delete all the points and/or the AnimPath object and start again without incurring in errors
- Comments and refactoring for aiding code readability